### PR TITLE
Created an experiment validator to shared between the feature service and client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.DS_Store
+.env

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,9 @@
+Copyright © 2014 by Intellectual Reserve, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+Except as contained in this notice, the name(s) of the above copyright holders shall not be used in advertising or otherwise to promote the sale, use or other dealings in this Software without prior written authorization.

--- a/index.js
+++ b/index.js
@@ -1,0 +1,8 @@
+/**
+ * This is a utility to enforce valid experiment data.
+ */
+
+
+module.exports = {
+  experimentValidator: require('./lib/experiment-validator')
+}

--- a/lib/experiment-validator.js
+++ b/lib/experiment-validator.js
@@ -1,0 +1,37 @@
+
+exports.isValid = isValid;
+
+/**
+ * Checks if the experiment is valid.
+ *
+ * @param experiment
+ * @returns {boolean}
+ */
+function isValid(experiment) {
+  var valid = false;
+  if (experiment && isValidName(experiment.name)) {
+    valid = true;
+  }
+  return valid;
+}
+
+/**
+ * Validates the experiment name.  An experiment must have a name and the name cannot contain whitespace
+ * characters (space, tab, carriage return, new line, vertical tab, and form feed).
+ *
+ * @param expName
+ * @returns {boolean}
+ */
+function isValidName(expName) {
+  var valid = false;
+  /* The regex checks for space, tab, carriage return, new line, vertical tab, and form feed characters. */
+  if (expName && !expName.match(/\s/g)) {
+    valid = true;
+  }
+
+  if (!valid) {
+    console.warn("Invalid experiment. The experiment name is either missing or contains whitespace characters. Experiment Name: '%s'", expName);
+  }
+  return valid;
+}
+

--- a/package.json
+++ b/package.json
@@ -14,5 +14,12 @@
   "bugs": {
     "url": "https://github.com/XPRMNTL/xpr-util-validation.js/issues"
   },
-  "homepage": "https://github.com/XPRMNTL/xpr-util-validation.js"
+  "homepage": "https://github.com/XPRMNTL/xpr-util-validation.js",
+  "devDependencies": {
+    "chai": "^2.0.0",
+    "mocha": "^2.1.0"
+  },
+  "scripts": {
+    "test": "NODE_ENV=test `pwd`/node_modules/.bin/mocha --reporter spec test/lib/**/*"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "xpr-util-validation",
+  "version": "0.0.1",
+  "description": "Shared js utility for experiment validation",
+  "main": "./index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "Jason Allen <allenjt@ldschurch.org>",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/XPRMNTL/xpr-util-validation.js"
+  },
+  "bugs": {
+    "url": "https://github.com/XPRMNTL/xpr-util-validation.js/issues"
+  },
+  "homepage": "https://github.com/XPRMNTL/xpr-util-validation.js"
+}

--- a/test/lib/experiment-validator-test.js
+++ b/test/lib/experiment-validator-test.js
@@ -1,0 +1,16 @@
+var assert = require("chai").assert
+  , experimentValidator = require("../../lib/experiment-validator");
+
+
+describe('Given an experiment with a valid name', function() {
+  describe('with a valid name', function() {
+    it('should return true', function () {
+      assert.isTrue(experimentValidator.isValid({name: 'ValidExperimentName'}));
+    })
+  });
+  describe('with an invalid name', function() {
+    it('should return false', function () {
+      assert.isFalse(experimentValidator.isValid({name: 'Invalid Experiment Name'}));
+    })
+  });
+});


### PR DESCRIPTION
# Problem space:
- Experiment names are not being validated.
- Experiment validation is not shared between the feature client and service.
 
# Changes:
- [ ] Created an experiment validator that validates the experiment name, with the intent that more validation will be added in the future.

# Should:
- [ ] Return false when an experiment is missing the name.
- [ ] Return false if the experiment name contains any whitespace characters as defined by the regex expression '\s' (space, tab, carriage return, new line, vertical tab, and form feed).
- [ ] Return true if the name exists and doesn't contain any whitespace characters.