### PR TITLE
Changed validation to only allow alpha-numeric names.

### DIFF
--- a/lib/experiment-validator.js
+++ b/lib/experiment-validator.js
@@ -16,21 +16,21 @@ function isValid(experiment) {
 }
 
 /**
- * Validates the experiment name.  An experiment must have a name and the name cannot contain whitespace
- * characters (space, tab, carriage return, new line, vertical tab, and form feed).
+ * Validates the experiment name.  An experiment must begin with an alpha character and only contain alpha-numeric
+ * characters thereafter.
  *
  * @param expName
  * @returns {boolean}
  */
 function isValidName(expName) {
   var valid = false;
-  /* The regex checks for space, tab, carriage return, new line, vertical tab, and form feed characters. */
-  if (expName && !expName.match(/\s/g)) {
+  /* The regex checks for a beginning alpha character and all subsequent characters must be alpha-numberic. */
+  if (expName && expName.match(/^[a-zA-Z][a-zA-Z0-9]*$/)) {
     valid = true;
   }
 
   if (!valid) {
-    console.warn("Invalid experiment. The experiment name is either missing or contains whitespace characters. Experiment Name: '%s'", expName);
+    console.warn("Invalid experiment. The experiment name must start with an alpha character and only contain alpha-numeric characters thereafter. Experiment Name: '%s'", expName);
   }
   return valid;
 }

--- a/package.json
+++ b/package.json
@@ -1,9 +1,13 @@
 {
   "name": "xpr-util-validation",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Shared js utility for experiment validation",
   "main": "./index.js",
   "author": "Jason Allen <allenjt@ldschurch.org>",
+  "homepage": "https://github.com/XPRMNTL/xpr-util-validation.js",
+  "keywords": [
+    "XPRMNTL"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/XPRMNTL/xpr-util-validation.js"
@@ -11,7 +15,6 @@
   "bugs": {
     "url": "https://github.com/XPRMNTL/xpr-util-validation.js/issues"
   },
-  "homepage": "https://github.com/XPRMNTL/xpr-util-validation.js",
   "devDependencies": {
     "chai": "^2.0.0",
     "mocha": "^2.1.0"

--- a/test/lib/experiment-validator-test.js
+++ b/test/lib/experiment-validator-test.js
@@ -1,16 +1,35 @@
-var assert = require("chai").assert
-  , experimentValidator = require("../../lib/experiment-validator");
+var expect = require("chai").expect
+  , experimentValidator = require("../../lib/experiment-validator")
+  , validExpNames = [
+    {name: 'ValidExperimentName'},
+    {name: 'Valid1Experiment2Name'}
+  ]
+  , invalidExpNames = [
+    {name: 'Invalid Experiment Name'},
+    {name: '9InvalidExperimentName'},
+    {name: 'Invalid-Experiment-Name'},
+    {name: 'Invalid.Experiment.Name'},
+    {name: 'Invalid_Experiment_Name'}
+  ];
 
 
 describe('Given an experiment with a valid name', function() {
   describe('with a valid name', function() {
     it('should return true', function () {
-      assert.isTrue(experimentValidator.isValid({name: 'ValidExperimentName'}));
+      var i = 0
+        , len = validExpNames.length;
+      for (; i < len; i++) {
+        expect(experimentValidator.isValid(validExpNames[i])).to.be.true;
+      }
     })
   });
   describe('with an invalid name', function() {
     it('should return false', function () {
-      assert.isFalse(experimentValidator.isValid({name: 'Invalid Experiment Name'}));
+      var i = 0
+        , len = invalidExpNames.length;
+      for (; i < len; i++) {
+        expect(experimentValidator.isValid(invalidExpNames[i])).to.be.false;
+      }
     })
   });
 });

--- a/test/lib/experiment-validator-test.js
+++ b/test/lib/experiment-validator-test.js
@@ -9,7 +9,8 @@ var expect = require("chai").expect
     {name: '9InvalidExperimentName'},
     {name: 'Invalid-Experiment-Name'},
     {name: 'Invalid.Experiment.Name'},
-    {name: 'Invalid_Experiment_Name'}
+    {name: 'Invalid_Experiment_Name'},
+    {name: ''}
   ];
 
 


### PR DESCRIPTION
# Problem space:
- Experiment names with '.', '-', or '_' characters cause the 'experiment' module dependency to throw an error.
 
# Changes:
- [ ] Changed experiment name validation to only allow alpha-numeric characters, where the first character must be an alpha character.  This is more compatible with the 'experiment' module dependency.
- [ ] Updated unit test to validate changes.
- [ ] Changed package.json version to 0.1.0.
 
# Should:
- [ ] Only allow experiment names with alpha-numeric characters.
- [ ] Only allow experiment names to begin with an alpha character.
